### PR TITLE
Fix typos for reproducing from deployment tutorial

### DIFF
--- a/config/pagecount.conf
+++ b/config/pagecount.conf
@@ -3,8 +3,8 @@ cassandra {
         port = 9042
         host = "127.0.0.1"
         keyspace = "wikipedia"
-        tableVisits = "visits"
-        tableMeta = "meta"
+        tableVisits = "page_visits"
+        tableMeta = "pagecount_metadata"
         username = "username"
         password = ""
     }

--- a/src/main/scala/ch/epfl/lts2/wikipedia/PagecountProcessor.scala
+++ b/src/main/scala/ch/epfl/lts2/wikipedia/PagecountProcessor.scala
@@ -144,7 +144,7 @@ object PagecountProcessor {
     val pgInputRdd = files.mapValues(p => pgCountProcessor.session.sparkContext.textFile(p))
     
     import pgCountProcessor.session.implicits._
-    val pcRdd = pgInputRdd.transform((d, p) => pgCountProcessor.parseLinesToDf(p, cfg.getInt("pagecountProcessor.minDailyVisits"), cfg.getInt("pagecountProcessor.minDailVisitsHourSplit"), d))
+    val pcRdd = pgInputRdd.transform((d, p) => pgCountProcessor.parseLinesToDf(p, cfg.getInt("pagecountProcessor.minDailyVisits"), cfg.getInt("pagecountProcessor.minDailyVisitsHourlySplit"), d))
     val dfVisits = pcRdd.values.reduce((p1, p2) => p1.union(p2)) // group all rdd's into one
     
     


### PR DESCRIPTION
I caught a few small typos in the code as I worked through the tutorial for processing the 20190820 dump along with pageviews between 2019-01-01 to 2019-03-01.

These are both related to the default pagecount config file. The first modification in the `PagecountProcessor` is fixing a deleted character. The second is based on [section 4.5 of the deployment tutorial](https://github.com/epfl-lts2/sparkwiki/blob/master/helpers/README.md#45-create-tables-to-import-pagecounts), where setting the default table names `page_visits` and `pagecount_metadata` seems reasonable. 