### PR TITLE
Dump Language Processor

### DIFF
--- a/src/main/scala/ch/epfl/lts2/wikipedia/DumpLangProcessor.scala
+++ b/src/main/scala/ch/epfl/lts2/wikipedia/DumpLangProcessor.scala
@@ -30,7 +30,7 @@ object DumpLangProcessor {
 
     val conf = new LangProcessorConf(args)
     val dumpParser = new DumpParser
-    
+
     val langLinksFile = Paths.get(conf.dumpPath(), conf.namePrefix() + "-langlinks.sql.bz2").toString
     val langLinksOutput = Paths.get(conf.outputPath(), conf.toLang.getOrElse("en")+"-langlinks").toString
     val langLinksDf = dumpParser.processFileToDf(dp.session, langLinksFile, WikipediaDumpType.LangLinks, conf.toLang.getOrElse("en") ).as[WikipediaLangLink]

--- a/src/main/scala/ch/epfl/lts2/wikipedia/DumpLangProcessor.scala
+++ b/src/main/scala/ch/epfl/lts2/wikipedia/DumpLangProcessor.scala
@@ -1,0 +1,45 @@
+package ch.epfl.lts2.wikipedia
+
+import java.nio.file.Paths
+
+import ch.epfl.lts2.wikipedia.DumpProcessor.dp
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SparkSession
+import org.rogach.scallop.{ScallopConf, Serialization}
+
+class LangProcessorConf(args:Seq[String]) extends ScallopConf(args) with Serialization {
+  val dumpPath = opt[String](required = true, name="dumpPath")
+  val outputPath = opt[String](required = true, name="outputPath")
+  val namePrefix = opt[String](required = true, name="namePrefix")
+  val toLang = opt[String](required = true, name="toLang")
+  verify()
+}
+
+class DumpLangProcessor extends Serializable {
+  lazy val sconf = new SparkConf().setAppName("Wikipedia dump processor")
+  lazy val session = SparkSession.builder.config(sconf).getOrCreate()
+
+}
+
+object DumpLangProcessor {
+
+  val dlp = new DumpLangProcessor
+
+  def main(args:Array[String]) = {
+    import dlp.session.implicits._
+
+    val conf = new LangProcessorConf(args)
+    val dumpParser = new DumpParser
+    //val sparkWikiParser = new SparkWikiParser
+
+
+    val langLinksFile = Paths.get(conf.dumpPath(), conf.namePrefix() + "-langlinks.sql.bz2").toString
+    val langLinksOutput = Paths.get(conf.outputPath(), conf.toLang.getOrElse("en")+"-langlinks").toString
+    val langLinksDf = dumpParser.processFileToDf(dp.session, langLinksFile, WikipediaDumpType.LangLinks, conf.toLang.getOrElse("en") ).as[WikipediaLangLink]
+
+    val normal_pages_langLinks = langLinksDf.filter( t => !t.title.contains(":") && t.title != "" )
+
+    dumpParser.writeCsv(normal_pages_langLinks.select("from", "title", "lang"), langLinksOutput)
+
+  }
+}

--- a/src/main/scala/ch/epfl/lts2/wikipedia/DumpLangProcessor.scala
+++ b/src/main/scala/ch/epfl/lts2/wikipedia/DumpLangProcessor.scala
@@ -30,9 +30,7 @@ object DumpLangProcessor {
 
     val conf = new LangProcessorConf(args)
     val dumpParser = new DumpParser
-    //val sparkWikiParser = new SparkWikiParser
-
-
+    
     val langLinksFile = Paths.get(conf.dumpPath(), conf.namePrefix() + "-langlinks.sql.bz2").toString
     val langLinksOutput = Paths.get(conf.outputPath(), conf.toLang.getOrElse("en")+"-langlinks").toString
     val langLinksDf = dumpParser.processFileToDf(dp.session, langLinksFile, WikipediaDumpType.LangLinks, conf.toLang.getOrElse("en") ).as[WikipediaLangLink]

--- a/src/main/scala/ch/epfl/lts2/wikipedia/DumpParser.scala
+++ b/src/main/scala/ch/epfl/lts2/wikipedia/DumpParser.scala
@@ -43,7 +43,7 @@ class DumpParser extends Serializable  with CsvWriter {
     parser.getDataFrame(session, records)
   }
   
-  def processFileToDf(session: SparkSession, inputFilename:String, dumpType:WikipediaDumpType.Value,toLang: String = "en"):DataFrame = {
+  def processFileToDf(session: SparkSession, inputFilename:String, dumpType:WikipediaDumpType.Value, toLang: String = "en"):DataFrame = {
     val lines = session.sparkContext.textFile(inputFilename, 4)
     processToDf(session, lines, dumpType, toLang)
   }

--- a/src/main/scala/ch/epfl/lts2/wikipedia/DumpProcessor.scala
+++ b/src/main/scala/ch/epfl/lts2/wikipedia/DumpProcessor.scala
@@ -50,7 +50,7 @@ class DumpProcessor extends Serializable {
   def getPagesByNamespace(pageDf: Dataset[WikipediaPage], ns: Int, keepRedirect: Boolean): Dataset[WikipediaSimplePage] = {
     import session.implicits._
     pageDf.filter(p => p.namespace == ns && (keepRedirect || !p.isRedirect))
-          .select("id", "title", "isRedirect", "isNew", "lang").as[WikipediaSimplePage]
+          .select("id", "title", "isRedirect", "isNew").as[WikipediaSimplePage]
   }
   
   def resolvePageRedirects(pgLinksIdDf:Dataset[MergedPageLink], redirectDf:Dataset[MergedRedirect], pages:Dataset[WikipediaSimplePage]):DataFrame = {
@@ -85,6 +85,7 @@ object DumpProcessor  {
     val pageFile = Paths.get(conf.dumpPath(), conf.namePrefix() + "-page.sql.bz2").toString
     val pageOutput = Paths.get(conf.outputPath(), "page")
     val pageDf = dumpParser.processFileToDf(dp.session, pageFile, WikipediaDumpType.Page).as[WikipediaPage]
+    
     
     val pageLinksFile = Paths.get(conf.dumpPath(), conf.namePrefix() + "-pagelinks.sql.bz2").toString
     val pageLinksOutput = Paths.get(conf.outputPath(), "pagelinks").toString

--- a/src/main/scala/ch/epfl/lts2/wikipedia/DumpProcessor.scala
+++ b/src/main/scala/ch/epfl/lts2/wikipedia/DumpProcessor.scala
@@ -50,7 +50,7 @@ class DumpProcessor extends Serializable {
   def getPagesByNamespace(pageDf: Dataset[WikipediaPage], ns: Int, keepRedirect: Boolean): Dataset[WikipediaSimplePage] = {
     import session.implicits._
     pageDf.filter(p => p.namespace == ns && (keepRedirect || !p.isRedirect))
-          .select("id", "title", "isRedirect", "isNew").as[WikipediaSimplePage]
+          .select("id", "title", "isRedirect", "isNew", "lang").as[WikipediaSimplePage]
   }
   
   def resolvePageRedirects(pgLinksIdDf:Dataset[MergedPageLink], redirectDf:Dataset[MergedRedirect], pages:Dataset[WikipediaSimplePage]):DataFrame = {
@@ -85,7 +85,6 @@ object DumpProcessor  {
     val pageFile = Paths.get(conf.dumpPath(), conf.namePrefix() + "-page.sql.bz2").toString
     val pageOutput = Paths.get(conf.outputPath(), "page")
     val pageDf = dumpParser.processFileToDf(dp.session, pageFile, WikipediaDumpType.Page).as[WikipediaPage]
-    
     
     val pageLinksFile = Paths.get(conf.dumpPath(), conf.namePrefix() + "-pagelinks.sql.bz2").toString
     val pageLinksOutput = Paths.get(conf.outputPath(), "pagelinks").toString

--- a/src/main/scala/ch/epfl/lts2/wikipedia/WikipediaElement.scala
+++ b/src/main/scala/ch/epfl/lts2/wikipedia/WikipediaElement.scala
@@ -13,6 +13,7 @@ object WikipediaDumpType extends Enumeration {
   val Redirect = Value("redirect")
   val Category = Value("category")
   val CategoryLinks = Value("categorylinks")
+  val LangLinks = Value("langlinks")
 }
 
 object WikipediaNamespace extends Enumeration {
@@ -33,8 +34,9 @@ case class WikipediaPage(id:Int, namespace:Int, title:String, restriction:String
                           latest:Int, len:Int, contentModel:String) extends WikipediaElement
                           
 case class WikipediaSimplePage(id:Int, title:String, isRedirect:Boolean, isNew: Boolean) extends WikipediaElement                          
-case class WikipediaPageLink(from:Int, namespace:Int, title:String, fromNamespace:Int) extends WikipediaElement 
+case class WikipediaPageLink(from:Int, namespace:Int, title:String, fromNamespace:Int) extends WikipediaElement
 
+case class WikipediaLangLink(from:Int, lang:String, title:String) extends WikipediaElement
 
 case class WikipediaRedirect(from:Int, targetNamespace:Int, title:String, interwiki:String, fragment:String) extends WikipediaElement 
 

--- a/src/main/scala/ch/epfl/lts2/wikipedia/WikipediaElement.scala
+++ b/src/main/scala/ch/epfl/lts2/wikipedia/WikipediaElement.scala
@@ -31,9 +31,9 @@ abstract class WikipediaElement extends Serializable
 
 case class WikipediaPage(id:Int, namespace:Int, title:String, restriction:String, 
                           isRedirect:Boolean, isNew:Boolean, random:Double, touched:Timestamp, linksUpdated:String,
-                          latest:Int, len:Int, contentModel:String) extends WikipediaElement
+                          latest:Int, len:Int, contentModel:String, lang:String ) extends WikipediaElement
                           
-case class WikipediaSimplePage(id:Int, title:String, isRedirect:Boolean, isNew: Boolean) extends WikipediaElement                          
+case class WikipediaSimplePage(id:Int, title:String, isRedirect:Boolean, isNew:Boolean, lang:String ) extends WikipediaElement
 case class WikipediaPageLink(from:Int, namespace:Int, title:String, fromNamespace:Int) extends WikipediaElement
 
 case class WikipediaLangLink(from:Int, lang:String, title:String) extends WikipediaElement

--- a/src/main/scala/ch/epfl/lts2/wikipedia/WikipediaElement.scala
+++ b/src/main/scala/ch/epfl/lts2/wikipedia/WikipediaElement.scala
@@ -31,9 +31,9 @@ abstract class WikipediaElement extends Serializable
 
 case class WikipediaPage(id:Int, namespace:Int, title:String, restriction:String, 
                           isRedirect:Boolean, isNew:Boolean, random:Double, touched:Timestamp, linksUpdated:String,
-                          latest:Int, len:Int, contentModel:String, lang:String ) extends WikipediaElement
+                          latest:Int, len:Int, contentModel:String) extends WikipediaElement
                           
-case class WikipediaSimplePage(id:Int, title:String, isRedirect:Boolean, isNew:Boolean, lang:String ) extends WikipediaElement
+case class WikipediaSimplePage(id:Int, title:String, isRedirect:Boolean, isNew: Boolean) extends WikipediaElement                          
 case class WikipediaPageLink(from:Int, namespace:Int, title:String, fromNamespace:Int) extends WikipediaElement
 
 case class WikipediaLangLink(from:Int, lang:String, title:String) extends WikipediaElement

--- a/src/main/scala/ch/epfl/lts2/wikipedia/WikipediaElementParser.scala
+++ b/src/main/scala/ch/epfl/lts2/wikipedia/WikipediaElementParser.scala
@@ -81,6 +81,22 @@ class WikipediaPageLinkParser extends Serializable with WikipediaElementParser[W
   def getDataFrame(session:SparkSession, data:RDD[String]):DataFrame = session.createDataFrame(getRDD(data))
 }
 
+class WikipediaLangLinkParser(lang: String) extends Serializable with WikipediaElementParser[WikipediaLangLink] {
+  val llRegex = """\((\d+),'(.*?)','(.*?)'\)""".r
+
+  def parseLine(lineInput: String):List[WikipediaLangLink] = {
+    val r = llRegex.findAllIn(lineInput).matchData.toList
+    r.map(m => WikipediaLangLink(m.group(1).toInt, m.group(2), m.group(3).replace(" ","_")))
+  }
+
+  def filterElt(t:WikipediaLangLink): Boolean = ( t.lang == this.lang )
+
+  def getRDD(lines: RDD[String]): RDD[WikipediaLangLink] = {
+    lines.flatMap(l => parseLine(l)).filter(filterElt)
+  }
+  def getDataFrame(session:SparkSession, data:RDD[String]):DataFrame = session.createDataFrame(getRDD(data))
+}
+
 class WikipediaRedirectParser extends Serializable with WikipediaElementParser[WikipediaRedirect] {
   /* TABLE `redirect` (
   `rd_from` int(8) unsigned NOT NULL DEFAULT '0',

--- a/src/main/scala/ch/epfl/lts2/wikipedia/WikipediaElementParser.scala
+++ b/src/main/scala/ch/epfl/lts2/wikipedia/WikipediaElementParser.scala
@@ -43,7 +43,7 @@ class WikipediaPageParser extends Serializable with WikipediaElementParser[Wikip
     r.map(m =>  WikipediaPage(m.group(1).toInt, m.group(2).toInt, m.group(3), m.group(4),
                         m.group(5).toInt == 1, m.group(6).toInt == 1, m.group(7).toDouble, 
                         new Timestamp(timestampFormat.parse(m.group(8)).getTime), m.group(9), m.group(10).toInt, 
-                        m.group(11).toInt, m.group(12), m.group(13)))
+                        m.group(11).toInt, m.group(12)))
       
   }
     

--- a/src/main/scala/ch/epfl/lts2/wikipedia/WikipediaElementParser.scala
+++ b/src/main/scala/ch/epfl/lts2/wikipedia/WikipediaElementParser.scala
@@ -43,7 +43,7 @@ class WikipediaPageParser extends Serializable with WikipediaElementParser[Wikip
     r.map(m =>  WikipediaPage(m.group(1).toInt, m.group(2).toInt, m.group(3), m.group(4),
                         m.group(5).toInt == 1, m.group(6).toInt == 1, m.group(7).toDouble, 
                         new Timestamp(timestampFormat.parse(m.group(8)).getTime), m.group(9), m.group(10).toInt, 
-                        m.group(11).toInt, m.group(12)))
+                        m.group(11).toInt, m.group(12), m.group(13)))
       
   }
     


### PR DESCRIPTION
Add support to pre-process the langlinks.sql.bz2 file.

This issue adds support to preprocess the language links contained in the file langlinks.sql.bz2 within the dumps.

The user will obtain the cross-lingual links to a particular Wikipedia language edition by calling the class DumpLangProcessor with the parameter --toLang which specifies the edition to filter in the preprocessing task. 

spark-submit --class ch.epfl.lts2.wikipedia.DumpLangProcessor --master 'yarn' --num-executors 4 --executor-memory 2g --driver-memory 2g --packages org.rogach:scallop_2.11:3.1.5,com.datastax.spark:spark-cassandra-connector_2.11:2.4.0 sparkwiki_2.11-0.10.2.jar --dumpPath WikiDumps/en/ --outputPath WikiSpark/en/ --namePrefix $enwiki-latest --toLang es